### PR TITLE
Add --dev flag to install command and add dot files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ cython_debug/
 *.iml
 requirements.txt
 .python-version
+.envrc

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ cython_debug/
 .idea
 *.iml
 requirements.txt
+.python-version

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Please make sure you have the following installed and can run them
 
 ## Install all dependencies
 ```bash
-pipenv install
+pipenv install --dev
 ```
 
 ## Run tests


### PR DESCRIPTION
This PR adds the `--dev` flag to the `pipinv install` command in the README instructions, so that pytest is installed into the environment.

It also adds dot files for pyenv and direnv to .gitignore