### PR TITLE
Remove deprecated/unavailable cask brew command

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,7 +5,7 @@ echo "Installing homebrew if it's not installed..."
 which brew || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
 echo "Installing docker if it's not installed..."
-which docker || brew cask install docker
+which docker || brew install docker
 
 echo "Installing java if it's not installed..."
 which java


### PR DESCRIPTION
As of Brew 2.6, `cask` is deprecated (https://brew.sh/2020/12/01/homebrew-2.6.0/), and it seems to have been removed from the latest versions of brew, so this command can fail on new/updated versions of brew. I think `docker` should be what we want, but if we still want the cask, we can install that instead.