### PR TITLE
edited spark wget link on dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ USER root
 WORKDIR /opt
 RUN wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.11%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.11_9.tar.gz && \
     wget https://downloads.lightbend.com/scala/2.13.5/scala-2.13.5.tgz && \
-    wget https://dlcdn.apache.org/spark/spark-3.2.1/spark-3.2.1-bin-hadoop3.2.tgz
+    wget https://archive.apache.org/dist/spark/spark-3.2.1/spark-3.2.1-bin-hadoop3.2.tgz
 RUN tar xzf OpenJDK11U-jdk_x64_linux_hotspot_11.0.11_9.tar.gz && \
     tar xvf scala-2.13.5.tgz && \
     tar xvf spark-3.2.1-bin-hadoop3.2.tgz


### PR DESCRIPTION
Edited the source link for spark on the Dockerfile as Apache has updated it on its servers.

Old link: `https://dlcdn.apache.org/spark/spark-3.2.1/spark-3.2.1-bin-hadoop3.2.tgz`
New link: `https://archive.apache.org/dist/spark/spark-3.2.1/spark-3.2.1-bin-hadoop3.2.tgz`