### PR TITLE
feat: add support for linting using docker-desktop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG PYTHON_VERSION=3.9.10
-FROM --platform=linux/amd64 python:$PYTHON_VERSION
+#FROM --platform=linux/amd64 python:$PYTHON_VERSION
+FROM python:$PYTHON_VERSION
 USER root
 WORKDIR /opt
 RUN if [ "$(arch)" = "aarch64" ] ; then ARCHITECTURE="aarch64" ; else ARCHITECTURE="x64"; fi && \

--- a/go.sh
+++ b/go.sh
@@ -72,6 +72,10 @@ while true; do
         operations+=( run-docker-desktop-integration-test )
         shift
         ;;
+    run-docker-desktop-linting)
+        operations+=( run-docker-desktop-linting )
+        shift
+        ;;        
     run-colima-integration-test)
             operations+=( run-colima-integration-test )
             shift
@@ -113,6 +117,7 @@ function usage() {
     trace "$0 <command> [--] [options ...]"
     trace "Commands:"
     trace "    linting   Static analysis, code style, etc.(please install poetry if you would like to use this command)"
+    trace "    run-docker-desktop-linting   Run linting before using Docker Desktop "    
     trace "    precommit Run sensible checks before committing"
     trace "    install-with-docker-desktop       Install the application requirements along with docker desktop"
     trace "    install-with-colima       Install the application requirements along with colima"
@@ -194,6 +199,11 @@ function run-docker-desktop-integration-test() {
     ./scripts/mac_or_linux/run-docker-desktop-integration-test.sh "${subcommand_opts[@]:+${subcommand_opts[@]}}"
 }
 
+function run-docker-desktop-linting() {
+    trace "Running linting using Docker Desktop"
+    ./scripts/mac_or_linux/run-docker-desktop-linting.sh "${subcommand_opts[@]:+${subcommand_opts[@]}}"
+}
+
 
 function run-local-job() {
     trace "Running job on local machine"
@@ -263,6 +273,10 @@ fi
 if contains run-docker-desktop-job "${operations[@]}"; then
     run-docker-desktop-job
 fi
+if contains run-docker-desktop-linting "${operations[@]}"; then
+    run-docker-desktop-linting
+fi
+
 
 
 trace "Exited cleanly."

--- a/scripts/mac_or_linux/run-docker-desktop-linting.sh
+++ b/scripts/mac_or_linux/run-docker-desktop-linting.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+set -euo pipefail
+./batect style-checks


### PR DESCRIPTION
## Overview
- [X] Add linting using docker-desktop to go.sh
- [X] Allow users of ARM based macs their native python image. 

Image [python:3.9.10](https://hub.docker.com/layers/library/python/3.9.10/images/sha256-f02ca062c296a4dfa35aed780817689f5c2cda469e1b349968713cf272a1b3a0?context=explore) has now support for arm64 platform.

Note: The current platform `amd64` at the Dockerfile may produce unwanted behaviors on mac-m1 machines and be slower on executions.  


## Test of linting

Testing `./go.sh run-docker-desktop-linting` using docker:
```bash 
$ ./go.sh run-docker-desktop-linting
Running linting using Docker Desktop
Version 0.85.0 of Batect is now available (you have 0.82.0).
To upgrade to the latest version, run './batect --upgrade'.
For more information, visit https://github.com/batect/batect/releases/tag/0.85.0.

Running style-checks...
pyspark: running

Running type checks
Success: no issues found in 13 source files
Running lint checks
************* Module tests.integration.test_distance_transformer
tests/integration/test_distance_transformer.py:122:20: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
tests/integration/test_distance_transformer.py:123:23: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
************* Module tests.integration.test_ingest
tests/integration/test_ingest.py:35:20: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
tests/integration/test_ingest.py:36:23: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
************* Module tests.integration.test_word_count
tests/integration/test_word_count.py:14:22: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)
tests/integration/test_word_count.py:18:18: C0209: Formatting a regular string which could be a f-string (consider-using-f-string)

-----------------------------------
Your code has been rated at 9.55/10


style-checks finished with exit code 16 in 2m 54s.
```

## UT

```bash 
$ ./go.sh run-docker-desktop-unit-test
Running unit tests on containers using Docker Desktop
Version 0.85.0 of Batect is now available (you have 0.82.0).
To upgrade to the latest version, run './batect --upgrade'.
For more information, visit https://github.com/batect/batect/releases/tag/0.85.0.

Running unit-test...
pyspark: running

=========================================================================================================== test session starts ============================================================================================================
platform linux -- Python 3.9.10, pytest-6.2.5, py-1.11.0, pluggy-1.3.0
rootdir: /app
collected 3 items

tests/unit/test_ingest.py ...                                                                                                                                                                                                        [100%]

============================================================================================================ 3 passed in 0.34s =============================================================================================================

unit-test finished with exit code 0 in 2.9s.
Exited cleanly.
```