### PR TITLE
Fix mypy and linter

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,5 +3,5 @@ from pyspark.sql import SparkSession
 
 
 @pytest.fixture(scope="session")
-def SPARK():
+def SPARK() -> SparkSession:
     return SparkSession.builder.appName("IntegrationTests").getOrCreate()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,5 +3,5 @@ from pyspark.sql import SparkSession
 
 
 @pytest.fixture(scope="session")
-def SPARK() -> SparkSession:
+def spark_session() -> SparkSession:
     return SparkSession.builder.appName("IntegrationTests").getOrCreate()

--- a/tests/integration/test_distance_transformer.py
+++ b/tests/integration/test_distance_transformer.py
@@ -81,7 +81,7 @@ SAMPLE_DATA = [
 ]
 
 
-def test_should_maintain_all_data_it_reads(SPARK) -> None:
+def test_should_maintain_all_data_it_reads(SPARK: SparkSession) -> None:
     given_ingest_folder, given_transform_folder = __create_ingest_and_transform_folders(SPARK)
     given_dataframe = SPARK.read.parquet(given_ingest_folder)
     distance_transformer.run(SPARK, given_ingest_folder, given_transform_folder)
@@ -97,7 +97,7 @@ def test_should_maintain_all_data_it_reads(SPARK) -> None:
 
 
 @pytest.mark.skip
-def test_should_add_distance_column_with_calculated_distance(SPARK) -> None:
+def test_should_add_distance_column_with_calculated_distance(SPARK: SparkSession) -> None:
     given_ingest_folder, given_transform_folder = __create_ingest_and_transform_folders(SPARK)
     distance_transformer.run(SPARK, given_ingest_folder, given_transform_folder)
 

--- a/tests/integration/test_distance_transformer.py
+++ b/tests/integration/test_distance_transformer.py
@@ -81,12 +81,13 @@ SAMPLE_DATA = [
 ]
 
 
-def test_should_maintain_all_data_it_reads(SPARK: SparkSession) -> None:
-    given_ingest_folder, given_transform_folder = __create_ingest_and_transform_folders(SPARK)
-    given_dataframe = SPARK.read.parquet(given_ingest_folder)
-    distance_transformer.run(SPARK, given_ingest_folder, given_transform_folder)
+def test_should_maintain_all_data_it_reads(spark_session: SparkSession) -> None:
+    given_ingest_folder, given_transform_folder = __create_ingest_and_transform_folders(
+        spark_session)
+    given_dataframe = spark_session.read.parquet(given_ingest_folder)
+    distance_transformer.run(spark_session, given_ingest_folder, given_transform_folder)
 
-    actual_dataframe = SPARK.read.parquet(given_transform_folder)
+    actual_dataframe = spark_session.read.parquet(given_transform_folder)
     actual_columns = set(actual_dataframe.columns)
     actual_schema = set(actual_dataframe.schema)
     expected_columns = set(given_dataframe.columns)
@@ -97,12 +98,13 @@ def test_should_maintain_all_data_it_reads(SPARK: SparkSession) -> None:
 
 
 @pytest.mark.skip
-def test_should_add_distance_column_with_calculated_distance(SPARK: SparkSession) -> None:
-    given_ingest_folder, given_transform_folder = __create_ingest_and_transform_folders(SPARK)
-    distance_transformer.run(SPARK, given_ingest_folder, given_transform_folder)
+def test_should_add_distance_column_with_calculated_distance(spark_session: SparkSession) -> None:
+    given_ingest_folder, given_transform_folder = __create_ingest_and_transform_folders(
+        spark_session)
+    distance_transformer.run(spark_session, given_ingest_folder, given_transform_folder)
 
-    actual_dataframe = SPARK.read.parquet(given_transform_folder)
-    expected_dataframe = SPARK.createDataFrame(
+    actual_dataframe = spark_session.read.parquet(given_transform_folder)
+    expected_dataframe = spark_session.createDataFrame(
         [
             SAMPLE_DATA[0] + [1.07],
             SAMPLE_DATA[1] + [0.92],

--- a/tests/integration/test_ingest.py
+++ b/tests/integration/test_ingest.py
@@ -8,7 +8,7 @@ from pyspark.sql import SparkSession
 from data_transformations.citibike import ingest
 
 
-def test_should_sanitize_column_names(SPARK: SparkSession) -> None:
+def test_should_sanitize_column_names(spark_session: SparkSession) -> None:
     given_ingest_folder, given_transform_folder = __create_ingest_and_transform_folders()
     input_csv_path = given_ingest_folder + 'input.csv'
     csv_content = [
@@ -17,10 +17,10 @@ def test_should_sanitize_column_names(SPARK: SparkSession) -> None:
         ['1', '5', '2'],
     ]
     __write_csv_file(input_csv_path, csv_content)
-    ingest.run(SPARK, input_csv_path, given_transform_folder)
+    ingest.run(spark_session, input_csv_path, given_transform_folder)
 
-    actual = SPARK.read.parquet(given_transform_folder)
-    expected = SPARK.createDataFrame(
+    actual = spark_session.read.parquet(given_transform_folder)
+    expected = spark_session.createDataFrame(
         [
             ['3', '4', '1'],
             ['1', '5', '2']

--- a/tests/integration/test_ingest.py
+++ b/tests/integration/test_ingest.py
@@ -3,10 +3,12 @@ import os
 import tempfile
 from typing import Tuple, List
 
+from pyspark.sql import SparkSession
+
 from data_transformations.citibike import ingest
 
 
-def test_should_sanitize_column_names(SPARK) -> None:
+def test_should_sanitize_column_names(SPARK: SparkSession) -> None:
     given_ingest_folder, given_transform_folder = __create_ingest_and_transform_folders()
     input_csv_path = given_ingest_folder + 'input.csv'
     csv_content = [

--- a/tests/integration/test_validate_spark_environment.py
+++ b/tests/integration/test_validate_spark_environment.py
@@ -1,36 +1,37 @@
 import os
 import re
 import subprocess
+from typing import Optional
 
 import pytest
 
 
-def test_java_home_is_set():
+def test_java_home_is_set() -> None:
     java_home = os.environ.get("JAVA_HOME")
     assert java_home is not None, "Environment variable 'JAVA_HOME' is not set but is required by pySpark to work."
 
 
-def test_java_version_minimum_requirement(expected_major_version=11):
+def test_java_version_minimum_requirement(expected_major_version:int =11) -> None:
     version_line = __extract_version_line(__java_version_output())
     major_version = __parse_major_version(version_line)
     assert major_version >= expected_major_version, (f"Major version {major_version} is not recent enough, "
                                                      f"we need at least version {expected_major_version}.")
 
 
-def __java_version_output():
+def __java_version_output() -> str:
     java_version = subprocess.check_output(['java', '-version'], stderr=subprocess.STDOUT).decode("utf-8")
     print(f"\n`java -version` returned\n{java_version}")
     return java_version
 
 
-def __extract_version_line(java_version_output):
+def __extract_version_line(java_version_output:str) -> str:
     version_line = next((line for line in java_version_output.splitlines() if "version" in line), None)
     if not version_line:
         pytest.fail("Couldn't find version information in `java -version` output.")
     return version_line
 
 
-def __parse_major_version(version_line):
+def __parse_major_version(version_line:str) -> Optional[int]:
     version_regex = re.compile(r'version "(?P<major>\d+)\.(?P<minor>\d+)\.\d+"')
     match = version_regex.search(version_line)
     if not match:

--- a/tests/integration/test_validate_spark_environment.py
+++ b/tests/integration/test_validate_spark_environment.py
@@ -31,14 +31,12 @@ def __extract_version_line(java_version_output:str) -> str:
     return version_line
 
 
-def __parse_major_version(version_line:str) -> Optional[int]:
+def __parse_major_version(version_line:str) -> int:
     version_regex = re.compile(r'version "(?P<major>\d+)\.(?P<minor>\d+)\.\d+"')
     match = version_regex.search(version_line)
-    if not match:
-        return None
-    major_version = int(match.group("major"))
-    if major_version == 1:
-        major_version = int(match.group("minor"))
-    if major_version is None:
-        pytest.fail(f"Couldn't parse Java version from {version_line}.")
-    return major_version
+    if match:
+        major_version = int(match.group("major"))
+        if major_version == 1: # Java 8 reports version as 1.actual_major.actual_minor
+            major_version = int(match.group("minor"))
+        return major_version
+    pytest.fail(f"Couldn't parse Java version from {version_line}.")

--- a/tests/integration/test_validate_spark_environment.py
+++ b/tests/integration/test_validate_spark_environment.py
@@ -34,6 +34,7 @@ def __extract_version_line(java_version_output: str) -> str:
     return version_line
 
 
+# pylint: disable=R1710
 def __parse_major_version(version_line: str) -> int:
     version_regex = re.compile(r'version "(?P<major>\d+)\.(?P<minor>\d+)\.\w+"')
     match = version_regex.search(version_line)

--- a/tests/integration/test_validate_spark_environment.py
+++ b/tests/integration/test_validate_spark_environment.py
@@ -1,7 +1,6 @@
 import os
 import re
 import subprocess
-from typing import Optional
 
 import pytest
 
@@ -11,7 +10,7 @@ def test_java_home_is_set() -> None:
     assert java_home is not None, "Environment variable 'JAVA_HOME' is not set but is required by pySpark to work."
 
 
-def test_java_version_minimum_requirement(expected_major_version:int =11) -> None:
+def test_java_version_minimum_requirement(expected_major_version: int = 11) -> None:
     version_line = __extract_version_line(__java_version_output())
     major_version = __parse_major_version(version_line)
     assert major_version >= expected_major_version, (f"Major version {major_version} is not recent enough, "
@@ -24,19 +23,21 @@ def __java_version_output() -> str:
     return java_version
 
 
-def __extract_version_line(java_version_output:str) -> str:
+def __extract_version_line(java_version_output: str) -> str:
     version_line = next((line for line in java_version_output.splitlines() if "version" in line), None)
     if not version_line:
         pytest.fail("Couldn't find version information in `java -version` output.")
     return version_line
 
 
-def __parse_major_version(version_line:str) -> int:
-    version_regex = re.compile(r'version "(?P<major>\d+)\.(?P<minor>\d+)\.\d+"')
+def __parse_major_version(version_line: str) -> int:
+    version_regex = re.compile(r'version "(?P<major>\d+)\.(?P<minor>\d+)\.\w+"')
     match = version_regex.search(version_line)
-    if match:
+    if match is not None:
         major_version = int(match.group("major"))
-        if major_version == 1: # Java 8 reports version as 1.actual_major.actual_minor
+        if major_version == 1:
+            # we need to jump this hoop due to Java version naming conventions - it's fun:
+            # https://softwareengineering.stackexchange.com/questions/175075/why-is-java-version-1-x-referred-to-as-java-x
             major_version = int(match.group("minor"))
         return major_version
     pytest.fail(f"Couldn't parse Java version from {version_line}.")

--- a/tests/integration/test_validate_spark_environment.py
+++ b/tests/integration/test_validate_spark_environment.py
@@ -7,24 +7,28 @@ import pytest
 
 def test_java_home_is_set() -> None:
     java_home = os.environ.get("JAVA_HOME")
-    assert java_home is not None, "Environment variable 'JAVA_HOME' is not set but is required by pySpark to work."
+    assert java_home is not None, \
+        "Environment variable 'JAVA_HOME' is not set but is required by pySpark to work."
 
 
 def test_java_version_minimum_requirement(expected_major_version: int = 11) -> None:
     version_line = __extract_version_line(__java_version_output())
     major_version = __parse_major_version(version_line)
-    assert major_version >= expected_major_version, (f"Major version {major_version} is not recent enough, "
-                                                     f"we need at least version {expected_major_version}.")
+    assert major_version >= expected_major_version, (
+        f"Major version {major_version} is not recent enough, "
+        f"we need at least version {expected_major_version}.")
 
 
 def __java_version_output() -> str:
-    java_version = subprocess.check_output(['java', '-version'], stderr=subprocess.STDOUT).decode("utf-8")
+    java_version = subprocess.check_output(['java', '-version'], stderr=subprocess.STDOUT).decode(
+        "utf-8")
     print(f"\n`java -version` returned\n{java_version}")
     return java_version
 
 
 def __extract_version_line(java_version_output: str) -> str:
-    version_line = next((line for line in java_version_output.splitlines() if "version" in line), None)
+    version_line = next((line for line in java_version_output.splitlines() if "version" in line),
+                        None)
     if not version_line:
         pytest.fail("Couldn't find version information in `java -version` output.")
     return version_line

--- a/tests/integration/test_word_count.py
+++ b/tests/integration/test_word_count.py
@@ -3,6 +3,7 @@ import tempfile
 from typing import Tuple, List
 
 import pytest
+from pyspark.sql import SparkSession
 
 from data_transformations.wordcount import word_count_transformer
 
@@ -19,7 +20,7 @@ def _get_file_paths(input_file_lines: List[str]) -> Tuple[str, str]:
 
 
 @pytest.mark.skip
-def test_should_tokenize_words_and_count_them(SPARK) -> None:
+def test_should_tokenize_words_and_count_them(SPARK: SparkSession) -> None:
     lines = [
         "In my younger and more vulnerable years my father gave me some advice that I've been "
         "turning over in my mind ever since. \"Whenever you feel like criticising any one,\""

--- a/tests/integration/test_word_count.py
+++ b/tests/integration/test_word_count.py
@@ -20,7 +20,7 @@ def _get_file_paths(input_file_lines: List[str]) -> Tuple[str, str]:
 
 
 @pytest.mark.skip
-def test_should_tokenize_words_and_count_them(SPARK: SparkSession) -> None:
+def test_should_tokenize_words_and_count_them(spark_session: SparkSession) -> None:
     lines = [
         "In my younger and more vulnerable years my father gave me some advice that I've been "
         "turning over in my mind ever since. \"Whenever you feel like criticising any one,\""
@@ -47,9 +47,9 @@ def test_should_tokenize_words_and_count_them(SPARK: SparkSession) -> None:
     ]
     input_file_path, output_path = _get_file_paths(lines)
 
-    word_count_transformer.run(SPARK, input_file_path, output_path)
+    word_count_transformer.run(spark_session, input_file_path, output_path)
 
-    actual = SPARK.read.csv(output_path, header=True, inferSchema=True)
+    actual = spark_session.read.csv(output_path, header=True, inferSchema=True)
     expected_data = [
         ["a", 4],
         ["across", 1],
@@ -259,6 +259,6 @@ def test_should_tokenize_words_and_count_them(SPARK: SparkSession) -> None:
         ["you've", 1],
         ["younger", 1],
     ]
-    expected = SPARK.createDataFrame(expected_data, ["word", "count"])
+    expected = spark_session.createDataFrame(expected_data, ["word", "count"])
 
     assert actual.collect() == expected.collect()


### PR DESCRIPTION
This change fixes issues reported by `mypy`, as well as most `pylint` problems. 

In addition, it fixes the java version regex to work with java version 8 again, which was seemingly broken [here](https://github.com/techops-recsys-lateral-hiring/dataengineer-transformations-python/pull/60/commits/07e39e6017361786d47458212312a8e864b4f176). @jmolina4 , any chance you can test this regex in a gitpod environment, and maybe elucidate why you changed the regex in the first place?

Also, I chose not to fix [this pylint issue](https://pylint.pycqa.org/en/latest/user_guide/messages/convention/consider-using-f-string.html) because I don't have enough time to consider the implications right now. Since the code, and the tests are working - should we just disable this particular rule? 